### PR TITLE
Basic Travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: c
+
+env:
+    global:
+        - "HOST_IP=$(/sbin/ifconfig venet0:0 | grep 'inet addr' | awk -F: '{print $2}' | awk '{print $1}')"
+        - DOCKER_HOST=tcp://$HOST_IP:2375
+        - DOCKER_PORT_RANGE=2400:2500
+        - SLIRP_PORTS=$(seq 2375 2500)
+
+before_install:
+    - sudo sh -c "wget -qO- https://get.docker.io/gpg | apt-key add -"
+    - sudo sh -c "echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list"
+    - echo exit 101 | sudo tee /usr/sbin/policy-rc.d
+    - sudo chmod +x /usr/sbin/policy-rc.d
+
+install:
+    - sudo apt-get -qqy update
+    - sudo apt-get -qqy install lxc lxc-docker-1.2.0 slirp
+    - sudo sudo usermod -aG docker "$USER"
+    - git clone git://github.com/cptactionhank/sekexe
+
+before_script:
+    - "sekexe/run 'mount -t tmpfs -o size=8g tmpfs /var/lib/docker && docker -d -H tcp://0.0.0.0:2375' &"
+    - "while ! docker info &> /dev/null ; do sleep 1; done"
+    - docker pull gapsystem/gap-docker
+
+script:
+    - docker version


### PR DESCRIPTION
This PR introduces a basic travis-ci configuration. The configuration here currently only pulls the docker container.

I'm hoping that someone will add to this a new file in the repository and a line at the end of this `.travis.yml` like this:

```
    - docker run -t gapsystem/gap-docker hello.sh
```

where `hello.sh` is some simple Gap script. This would give more confidence that changes to this repository do not cause regression  bugs.
